### PR TITLE
Fix address alignment and typos

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -43,9 +43,8 @@
 \begin{document}
 
 \name{Dana Atchley Merrick}
-% this is sloppy but it's easy formatting
-\address{\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\, dana.merrick@gmail.com}
-\address{\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,\,USA-based -- 978.206.1331}
+\address{\makebox[3in][r]{dana.merrick@gmail.com}}
+\address{\makebox[3in][r]{USA-based -- 978.206.1331}}
 
 \begin{resume}
 
@@ -73,7 +72,7 @@
   Postmates,
   San Francisco, CA
   \begin{itemize}  \itemsep -2pt % reduce space between items
-    \item Lead infrastructure efforts for Postmate's ``delivery as a service'' developer API.
+    \item Led infrastructure efforts for Postmates' ``delivery as a service'' developer API.
     \item Built server functionality in Go -- including adding metrics, logging, tracing, and new features.
     \item Worked on build process and deploy pipeline using Docker and Kubernetes.
     \item Served as liaison between developer API team and the greater Postmates infrastructure team.
@@ -98,7 +97,7 @@
   \begin{itemize}  \itemsep -2pt % reduce space between items
     \item Built out a Vagrant developer environment that utilized the same Chef infrastructure code as the production environment.
     \item Designed and implemented a system to run integration testing suite against every pull request, catching many bugs before they were deployed.
-    \item Created a Github Enterprise server and migrated all private repositories/users.
+    \item Created a GitHub Enterprise server and migrated all private repositories/users.
     \item Moved a manually-maintained Nagios alerting system to one fully automated with Chef.
     \item Built countless internal tools to assist with development, testing, and deployment.
     \item Upgraded massive production MongoDB server cluster to the latest version with zero downtime.
@@ -123,7 +122,7 @@
   Brightcove / Zencoder,
   San Francisco, CA
   \begin{itemize}  \itemsep -2pt % reduce space between items
-    \item Lead the team responsible for replacing Brightcove's transcoding stack with Zencoder infrastructure.
+    \item Led the team responsible for replacing Brightcove's transcoding stack with Zencoder infrastructure.
     \item Helped design, build, and support a platform for cross-platform mobile development.
     \item Managed build farm, Postgres/MongoDB databases, Riak servers, Nagios systems, and Resque queues.
     \item Migrated the AWS infrastructure to both Vagrant and physical servers.
@@ -142,7 +141,7 @@
   BCM (formerly Backchannelmedia),
   Boston, MA
   \begin{itemize}  \itemsep -2pt % reduce space between items
-    \item Lead a small team of Ruby developers in designing, building, and launching a Rails 3 daily deal site.
+    \item Led a small team of Ruby developers in designing, building, and launching a Rails 3 daily deal site.
     \item Personally handled entire Rails deploy and release management process using Engine Yard, Heroku, and AWS.
     \item Earned a reputation as the resident Git expert; provided lessons, presentations, and advice on getting the most out of SCM in day-to-day development.
   \end{itemize}
@@ -158,9 +157,9 @@
   \textsl{System Administrator}  \hfill 2006-09 \\
   Integrated Computer Solutions,
   Bedford, MA
-  \begin{itemize}  \itemsep -2pt %reduce space between items
-       \item Managed all physical machines, including production servers, personal work stations, virtual machines, and legacy hardware.
-       \item Designed and built a custom server-monitoring system.
+  \begin{itemize}  \itemsep -2pt % reduce space between items
+    \item Managed all physical machines, including production servers, personal work stations, virtual machines, and legacy hardware.
+    \item Designed and built a custom server-monitoring system.
   \end{itemize}
 
 \section{EDUCATION}


### PR DESCRIPTION
## Summary
- Replace thin-space (`\,`) hack with proper `\makebox` alignment for right-aligned address lines
- Fix "Lead" → "Led" (past tense, 3 occurrences)
- Fix "Postmate's" → "Postmates'" (possessive of company name)
- Fix "Github" → "GitHub" (capitalization)
- Normalize inconsistent indentation in last job entry

## Test plan
- [ ] Verify PDF renders with address lines right-aligned flush to page margin
- [ ] Spot-check typo fixes in rendered output