### PR TITLE
Add publish workflow for resume PDF

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish Resume PDF
+on:
+  workflow_dispatch:
+    inputs:
+      date:
+        description: 'Date for the PDF filename (YYYY-MM-DD). Defaults to today.'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: xu-cheng/latex-action@v3
+      with:
+        root_file: resume.tex
+    - name: Replace PDF
+      run: |
+        DATE="${{ inputs.date }}"
+        if [ -z "$DATE" ]; then
+          DATE=$(date +%Y-%m-%d)
+        fi
+        git rm resume.*.pdf
+        mv resume.pdf "resume.${DATE}.pdf"
+        git add "resume.${DATE}.pdf"
+    - name: Commit and push
+      run: |
+        DATE="${{ inputs.date }}"
+        if [ -z "$DATE" ]; then
+          DATE=$(date +%Y-%m-%d)
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git commit -m "Publish resume.${DATE}.pdf"
+        git push

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,26 +12,27 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      DATE: ${{ inputs.date }}
     steps:
     - uses: actions/checkout@v4
     - uses: xu-cheng/latex-action@v3
       with:
         root_file: resume.tex
-    - name: Replace PDF
+    - name: Set date
       run: |
-        DATE="${{ inputs.date }}"
         if [ -z "$DATE" ]; then
-          DATE=$(date +%Y-%m-%d)
+          echo "DATE=$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
         fi
+    - name: Replace PDF and update README
+      run: |
         git rm resume.*.pdf
         mv resume.pdf "resume.${DATE}.pdf"
         git add "resume.${DATE}.pdf"
+        sed -i "s|resume\.[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}\.pdf|resume.${DATE}.pdf|g" README.md
+        git add README.md
     - name: Commit and push
       run: |
-        DATE="${{ inputs.date }}"
-        if [ -z "$DATE" ]; then
-          DATE=$(date +%Y-%m-%d)
-        fi
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git commit -m "Publish resume.${DATE}.pdf"


### PR DESCRIPTION
## Summary
- Adds a manually-triggered (`workflow_dispatch`) workflow that builds the resume PDF, removes the old dated copy, and commits the new one to master
- Date defaults to today (`YYYY-MM-DD`) but can be overridden via input — useful for testing without making it look like a content update

## Test plan
- [ ] Merge to master, then trigger manually from Actions tab with date `2021-10-21` to verify it works without changing the visible date
- [ ] Trigger again with no date input to confirm it uses today's date