### PR TITLE
Update Reverie Labs title to Staff Software Engineer

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -69,7 +69,7 @@
     \item Developed self-service developer tooling including Streamlit apps for VM management, CLI tools, and pipelines with GitLab CI.
   \end{itemize}
 
-  \textsl{Senior Infrastructure Engineer}  \hfill 2020-24 \\
+  \textsl{Staff Software Engineer}  \hfill 2020-24 \\
   Reverie Labs {\scriptsize\textsf{(YC W18)}},
   Cambridge, MA (acquired by Ginkgo)
   \begin{itemize}  \itemsep -2pt % reduce space between items


### PR DESCRIPTION
## Summary
- Updates the Reverie Labs job title from "Senior Infrastructure Engineer" to "Staff Software Engineer" to match LinkedIn

## Test plan
- [ ] Verify PDF renders correctly with the new title