### PR TITLE
Bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install lint tools
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DATE: ${{ inputs.date }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: xu-cheng/latex-action@v3
       with:
         root_file: resume.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: '0'
     - uses: xu-cheng/latex-action@v3
       with:
         root_file: |
           resume.tex
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v5
       with:
         name: resume
         path: resume.pdf
     - name: Comment on PR with PDF link
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`;


### PR DESCRIPTION
## Summary
- Updates `actions/checkout` v4 → v5, `actions/upload-artifact` v4 → v5, `actions/github-script` v7 → v8
- Fixes Node.js 20 deprecation warnings in CI

## Test plan
- [ ] Verify all three workflows (linting, release, publish) pass without Node.js deprecation warnings