### PR TITLE
ci: bump pinned GitHub Actions to current latest stable

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install lint tools
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DATE: ${{ inputs.date }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: xu-cheng/latex-action@v3
       with:
         root_file: resume.tex

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       DATE: ${{ inputs.date }}
     steps:
     - uses: actions/checkout@v6
-    - uses: xu-cheng/latex-action@v3
+    - uses: xu-cheng/latex-action@v4
       with:
         root_file: resume.tex
     - name: Set date

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         root_file: |
           resume.tex
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@v7
       with:
         name: resume
         path: resume.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
-    - uses: xu-cheng/latex-action@v3
+    - uses: xu-cheng/latex-action@v4
       with:
         root_file: |
           resume.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
     - uses: xu-cheng/latex-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         path: resume.pdf
     - name: Comment on PR with PDF link
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`;


### PR DESCRIPTION
## Summary
- Bumps GitHub Actions pins in `.github/workflows/` to current latest stable. Mirrors the lessons from tripbot#436: prefer floating-major tags (`@v3` not `@v3.0.0`) so future minors flow in via dependabot, verify post-bump for input-shape changes on major bumps.
- Cross-repo sweep — tripbot side shipped via #436; infra + website are sibling PRs.

## Bumps
- `actions/checkout` `@v5` -> `@v6` (floating major; Node.js 24 runtime)
- `xu-cheng/latex-action` `@v3` -> `@v4` (floating major; Alpine/Debian image support + TeXLive 2026; `root_file` input unchanged)
- `actions/upload-artifact` `@v5` -> `@v7` (floating major; Node.js 24 + ESM + optional `archive` param; `name`/`path` inputs unchanged)
- `actions/github-script` `@v8` -> `@v9` (floating major; ESM upgrade — only breaking for scripts that `require('@actions/github')` or redeclare `getOctokit`. Our release.yml script does neither.)

## Deprecated/sunset (flagged, not bumped)
- None.

## Test plan
- [x] Workflow YAML parses
- [ ] Linting workflow runs green on this PR
- [ ] Build Resume workflow runs green and posts the PDF comment via github-script@v9