### PR TITLE
ci: action-version hygiene sweep

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install lint tools
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       DATE: ${{ inputs.date }}
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - uses: xu-cheng/latex-action@v3
       with:
         root_file: resume.tex

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: '0'
     - uses: xu-cheng/latex-action@v3
       with:
         root_file: |
           resume.tex
-    - uses: actions/upload-artifact@v5
+    - uses: actions/upload-artifact@v7
       with:
         name: resume
         path: resume.pdf
     - name: Comment on PR with PDF link
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         script: |
           const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`;


### PR DESCRIPTION
## Summary
Bump pinned GitHub Actions to current floating-major tags. Mirrors the recent tripbot (#436), infra (#480), and website (#225) sweeps.

## Changes

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | `@v5` | `@v6` | Floating-major; safe, used elsewhere across adanalife repos |
| `actions/upload-artifact` | `@v5` | `@v7` | v6 added Node.js 24 runtime, v7 added optional `archive: false` for direct uploads — default single-file upload behavior preserved |
| `actions/github-script` | `@v8` | `@v9` | v9 ESM upgrade breaks `require('@actions/github')`; our `release.yml` script uses the injected `github` octokit directly, no `require()` calls |

## Skipped this round

- `xu-cheng/latex-action@v3` → `@v4`: no release notes published for v4.0.0 yet. Holding on @v3 until upstream documents the major bump.

## Test plan
- [x] Eyeballed diff — version-string changes only, no logic drift
- [ ] CI: linting + publish + release workflows run green on this PR